### PR TITLE
Chat 일부 로직 수정 및 Log 상세화

### DIFF
--- a/jPanda/src/main/java/com/kakao/jPanda/kts/config/WebSocketStompConfig.java
+++ b/jPanda/src/main/java/com/kakao/jPanda/kts/config/WebSocketStompConfig.java
@@ -1,19 +1,29 @@
 package com.kakao.jPanda.kts.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import com.kakao.jPanda.kts.handler.StompHandShakeInterceptor;
 
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketStompConfig implements WebSocketMessageBrokerConfigurer {
 	
+    private final StompHandShakeInterceptor stompHandShakeInterceptor;
+    
+    @Autowired
+    public WebSocketStompConfig(StompHandShakeInterceptor stompHandShakeInterceptor) {
+        this.stompHandShakeInterceptor = stompHandShakeInterceptor;
+    }
+    
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/stomp/chat")
 				.setAllowedOriginPatterns("http://localhost:8888")
+				.addInterceptors(stompHandShakeInterceptor)
 				.withSockJS();
 	}
 	

--- a/jPanda/src/main/java/com/kakao/jPanda/kts/controller/ChatController.java
+++ b/jPanda/src/main/java/com/kakao/jPanda/kts/controller/ChatController.java
@@ -1,9 +1,7 @@
 package com.kakao.jPanda.kts.controller;
 
 import java.util.List;
-
 import javax.validation.Valid;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -15,11 +13,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-
 import com.kakao.jPanda.kts.domain.Chat;
 import com.kakao.jPanda.kts.domain.Partner;
 import com.kakao.jPanda.kts.service.ChatService;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -32,19 +28,19 @@ public class ChatController {
 	public ChatController(ChatService chatService) {
 		this.chatService = chatService;
 	}
-	
-	@ResponseBody
-	@GetMapping("/chats")
-	public List<Chat> chatListByMemberId(@RequestParam String memberId){
-		log.info("[chatListByMemberId]");
-		List<Chat> foundChatList = chatService.findChatListByMemberId(memberId);	
-		return foundChatList;
-	}
+    
+    @ResponseBody
+    @GetMapping("/chats/{memberId}")
+    public List<Chat> chatListByMemberIdAndPartnerId(@PathVariable String memberId, @RequestParam(name = "partner-id") String partnerId){
+        log.info("[chatListByMemberIdAndPartnerId] {}의 상대 {}와의 채팅 정보를 불러옵니다.", memberId, partnerId);
+        List<Chat> foundChatList = chatService.findChatListByMemberIdAndPartnerId(memberId, partnerId);    
+        return foundChatList;
+    }
 	
 	@ResponseBody
 	@GetMapping("/chats/{memberId}/partners")
 	public List<Partner> partnerListByMemberId(@PathVariable String memberId){
-		log.info("[partnerListByMemberId]");
+		log.info("[partnerListByMemberId] {}의 채팅 상대 목록을 불러옵니다.", memberId);
 		List<Partner> foundPartnerList = chatService.findPartnerListByMemberId(memberId);
 		return foundPartnerList;
 	}
@@ -52,18 +48,20 @@ public class ChatController {
 	@MessageMapping("/message")
 	@SendToUser(value = "/direct/{memberId}", broadcast = false)
 	public Chat sendMessage(Chat chat) {
-		log.info("[sendMessage] chatInfo {}", chat.toString());
+		log.info("[sendMessage] 메세지를 전송합니다. {}", chat.toString());
 		return chat;
 	}
 	
 	@ResponseBody
 	@PostMapping("/chat")
 	public ResponseEntity<Integer> chatSave(@Valid @RequestBody Chat chat){
-		log.info("[chatSave]");
+		log.info("[chatSave] 메세지를 DB에 저장합니다. {}", chat.toString());
 		Integer result = chatService.saveChat(chat);
 		if(result == 1) {
+		    log.info("[chatSave] 저장 완료 {}", result);
 			return ResponseEntity.accepted().body(result);
 		} else {
+            log.info("[chatSave] 저장 실패 {}", result);
 			return ResponseEntity.internalServerError().body(result);
 		}
 	}

--- a/jPanda/src/main/java/com/kakao/jPanda/kts/dao/ChatDao.java
+++ b/jPanda/src/main/java/com/kakao/jPanda/kts/dao/ChatDao.java
@@ -1,6 +1,7 @@
 package com.kakao.jPanda.kts.dao;
 
 import java.util.List;
+import java.util.Map;
 import com.kakao.jPanda.kts.domain.Chat;
 import com.kakao.jPanda.kts.domain.Partner;
 
@@ -8,8 +9,8 @@ public interface ChatDao {
 
 	Integer insertChat(Chat chat);
 
-	List<Chat> selectChatListByMemberId(String memberId);
-
 	List<Partner> selectPartnerListByMemberId(String memberId);
+
+    List<Chat> selectChatListByMemberIdAndPartnerId(Map<String, String> memberIdAndPartnerMap);
 
 }

--- a/jPanda/src/main/java/com/kakao/jPanda/kts/dao/impl/ChatDaoImpl.java
+++ b/jPanda/src/main/java/com/kakao/jPanda/kts/dao/impl/ChatDaoImpl.java
@@ -1,6 +1,7 @@
 package com.kakao.jPanda.kts.dao.impl;
 
 import java.util.List;
+import java.util.Map;
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -19,12 +20,6 @@ public class ChatDaoImpl implements ChatDao {
 	}
 
 	@Override
-	public List<Chat> selectChatListByMemberId(String memberId) {
-	    List<Chat> selectedChatList = sqlSession.selectList("selectChatListByMemberId", memberId);
-		return selectedChatList;
-	}
-
-	@Override
 	public Integer insertChat(Chat chat) {
 		int result = sqlSession.insert("insertChat", chat);
 		return result;
@@ -35,5 +30,12 @@ public class ChatDaoImpl implements ChatDao {
 		List<Partner> selectedPartnerList = sqlSession.selectList("selectPartnerListByMemberId", memberId);
 		return selectedPartnerList;
 	}
+
+    @Override
+    public List<Chat> selectChatListByMemberIdAndPartnerId(
+            Map<String, String> memberIdAndPartnerMap) {
+        List<Chat> selectedChatList = sqlSession.selectList("selectChatListByMemberIdAndPartnerId", memberIdAndPartnerMap);
+        return selectedChatList;
+    }
 	
 }

--- a/jPanda/src/main/java/com/kakao/jPanda/kts/handler/StompHandShakeInterceptor.java
+++ b/jPanda/src/main/java/com/kakao/jPanda/kts/handler/StompHandShakeInterceptor.java
@@ -1,0 +1,28 @@
+package com.kakao.jPanda.kts.handler;
+
+import java.util.Map;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class StompHandShakeInterceptor implements HandshakeInterceptor {
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+            WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        log.info("[beforeHandshake] {} 연결시도", request.getURI().getQuery());
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+            WebSocketHandler wsHandler, Exception exception) {
+        log.info("[afterHandshake] {} 연결되었습니다.", request.getURI().getQuery());
+    }
+
+}

--- a/jPanda/src/main/java/com/kakao/jPanda/kts/service/ChatService.java
+++ b/jPanda/src/main/java/com/kakao/jPanda/kts/service/ChatService.java
@@ -8,8 +8,8 @@ public interface ChatService {
 
 	Integer saveChat(Chat chat);
 
-	List<Chat> findChatListByMemberId(String memberId);
-
 	List<Partner> findPartnerListByMemberId(String memberId);
+
+    List<Chat> findChatListByMemberIdAndPartnerId(String memberId, String partnerId);
 
 }

--- a/jPanda/src/main/java/com/kakao/jPanda/kts/service/impl/ChatServiceImpl.java
+++ b/jPanda/src/main/java/com/kakao/jPanda/kts/service/impl/ChatServiceImpl.java
@@ -1,6 +1,8 @@
 package com.kakao.jPanda.kts.service.impl;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.kakao.jPanda.kts.dao.ChatDao;
@@ -19,8 +21,11 @@ public class ChatServiceImpl implements ChatService {
 	}
 	
 	@Override
-	public List<Chat> findChatListByMemberId(String memberId) {
-		List<Chat> selectedChatList = chatDao.selectChatListByMemberId(memberId);
+	public List<Chat> findChatListByMemberIdAndPartnerId(String memberId, String partnerId) {
+	    Map<String, String> memberIdAndPartnerMap = new HashMap<String, String>();
+	    memberIdAndPartnerMap.put("memberId", memberId);
+	    memberIdAndPartnerMap.put("partnerId", partnerId);
+	    List<Chat> selectedChatList = chatDao.selectChatListByMemberIdAndPartnerId(memberIdAndPartnerMap);
 		return selectedChatList;
 	}
 

--- a/jPanda/src/main/resources/mappers/kts/chatMapper.xml
+++ b/jPanda/src/main/resources/mappers/kts/chatMapper.xml
@@ -2,11 +2,11 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="chatMapper">
-	<select id="selectChatListByMemberId" parameterType="String" resultType="Chat">
+	<select id="selectChatListByMemberIdAndPartnerId" parameterType="Map" resultType="Chat">
 		SELECT *
 		FROM chat
-		WHERE receiver_id = #{memberId}
-			OR sender_id = #{memberId}
+		WHERE (receiver_id = #{memberId} AND sender_id = #{partnerId})
+			OR (sender_id = #{memberId} AND receiver_id = #{partnerId})
 		ORDER BY chat_date ASC
 	</select>
 	

--- a/jPanda/src/main/resources/templates/common/script/chat-js.html
+++ b/jPanda/src/main/resources/templates/common/script/chat-js.html
@@ -75,9 +75,8 @@
 		//채팅 대화 내용 업데이트
 		function updateChatContent() {
 			$.ajax({
-				url: "/chats",
+				url: "/chats/" + memberId + "?partner-id=" + selectedChat,
 				method: "GET",
-				data : {memberId : memberId},
 				dataType : "json",
 				success: function(chatList) {
 					console.log("chatList =>" + chatList);

--- a/jPanda/src/main/resources/templates/common/style/chat-css.html
+++ b/jPanda/src/main/resources/templates/common/style/chat-css.html
@@ -29,19 +29,20 @@
 		    background-repeat: no-repeat;
 		    background-position: 5px;
 		}
-		/* 채팅 입력창 스타일 */
-		#chat-input {
-			width: 100%;
-			height: 10%;
-			padding: 10px;
-			border: none;
-			border-top: 1px solid #ddd;
-			box-sizing: border-box;
-			resize: none;
-			overflow: auto;
-			position: absolute;
-			bottom: 0;
-			left: 0;
+	     
+	    /* 팝업 채팅창 스타일 */
+		#chat-console {
+			position: fixed;
+			right: 10px;
+			bottom: 10px;
+			width: 60%;
+			height: 70%;
+			background-color: white;
+			border: 1px solid #ccc;
+			border-radius: 5px;
+			box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.3);
+			z-index: 9999;
+			display: none;
 		}
 	     
 		/* 채팅 상대 목록 스타일 */
@@ -64,6 +65,21 @@
 			box-sizing: border-box;
 			padding: 10px;
 			overflow-y: auto; 
+		}
+		
+		/* 채팅 입력창 스타일 */
+		#chat-input {
+			width: 100%;
+			height: 10%;
+			padding: 10px;
+			border: none;
+			border-top: 1px solid #ddd;
+			box-sizing: border-box;
+			resize: none;
+			overflow: auto;
+			position: absolute;
+			bottom: 0;
+			left: 0;
 		}
 		
 		.chat-date {
@@ -97,21 +113,6 @@
 			align-items: flex-end;
 			margin: 10px;
 			justify-content: flex-end;
-		}
-	     
-	    /* 팝업 채팅창 스타일 */
-		#chat-console {
-			position: fixed;
-			right: 10px;
-			bottom: 10px;
-			width: 60%;
-			height: 70%;
-			background-color: white;
-			border: 1px solid #ccc;
-			border-radius: 5px;
-			box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.3);
-			z-index: 9999;
-			display: none;
 		}
 	
 		#chat-header {


### PR DESCRIPTION
채팅 상대와 무관하게 항상 로그인한 멤버의 모든 채팅을 가져와서 선택한 상대와의 채팅으로 Filtering 하였으나 추후 채팅 기록이 많으면 많을수록 비효율적인 과정을 거치는 것이므로
채팅 상대와 로그인한 멤버와의 채팅만 가져오는 로직으로 수정

Log를 통해 chat 기능 상태를 확인하기 위해 상세한 내용 기입
연결 시도 log를 추가하기위해 HandShakeInterceptor 추가