### PR TITLE
메인페이지, 공지사항 페이지 수정

### DIFF
--- a/jPanda/src/main/resources/mappers/bsm/TalentMapper.xml
+++ b/jPanda/src/main/resources/mappers/bsm/TalentMapper.xml
@@ -28,7 +28,7 @@
 		SELECT 	*
 		FROM	(SELECT 	t.talent_no, t.main_img, t.title, t.summary, m.name, NVL(r.review_avg_score, 0) AS review_avg_score, NVL(r.review_count, 0) AS review_count, c.item
 		         FROM      	talent t LEFT OUTER JOIN bamboo_use b ON t.talent_no = b.talent_no
-		                             JOIN member m 				  ON t.seller_id = m.member_id
+		                             INNER JOIN member m ON t.seller_id = m.member_id
 		                             LEFT OUTER JOIN (SELECT    talent_no, ROUND(AVG(bamboo_score), 1) AS review_avg_score, COUNT(*) AS review_count
 		                                              FROM      review 
 		                                              GROUP BY  talent_no) r 
@@ -44,8 +44,7 @@
 	<select id="selectTopRatedTalents" resultType="RegistTalent">
 		SELECT *
 		FROM   (SELECT   t.talent_no, t.main_img, t.title, t.summary, m.name, NVL(r.review_avg_score, 0) AS review_avg_score, NVL(r.review_count, 0) AS review_count, c.item
-		        FROM     talent t JOIN review r ON t.talent_no = r.talent_no
-		                          JOIN member m ON t.seller_id = m.member_id
+		        FROM     talent t INNER JOIN member m ON t.seller_id = m.member_id
 		                          LEFT OUTER JOIN (SELECT    talent_no, ROUND(AVG(bamboo_score), 1) AS review_avg_score, COUNT(*) AS review_count
 		                                           FROM      review 
 		                                           GROUP BY  talent_no) r 
@@ -62,7 +61,7 @@
 		SELECT   *        
 		FROM     (SELECT   t.talent_no, t.main_img, t.title, t.summary, m.name, NVL(r.review_avg_score, 0) AS review_avg_score, NVL(r.review_count, 0) AS review_count, c.item
 		          FROM     talent t LEFT OUTER JOIN bamboo_use b ON t.talent_no = b.talent_no
-		                            JOIN member m                ON t.seller_id = m.member_id
+		                            INNER JOIN member m ON t.seller_id = m.member_id
 		                            LEFT OUTER JOIN (SELECT    talent_no, ROUND(AVG(bamboo_score), 1) AS review_avg_score, COUNT(*) AS review_count
 		                                             FROM      review 
 		                                             GROUP BY  talent_no) r 
@@ -80,7 +79,7 @@
 	<select id="selectRandomTalents" resultType="RegistTalent">
 		SELECT  *
 		FROM    (SELECT   t.talent_no, t.main_img, t.title, t.summary, m.name, NVL(r.review_avg_score, 0) AS review_avg_score, NVL(r.review_count, 0) AS review_count, c.item
-		         FROM     talent t JOIN member m ON t.seller_id = m.member_id
+		         FROM     talent t INNER JOIN member m ON t.seller_id = m.member_id
 		                           LEFT OUTER JOIN (SELECT    talent_no, ROUND(AVG(bamboo_score), 1) AS review_avg_score, COUNT(*) AS review_count
 		                                            FROM      review 
 		                                            GROUP BY  talent_no) r 


### PR DESCRIPTION
메인페이지 최고평점 못 불러오는 오류 해결
매퍼 전부 안시 조인으로 수정 후 작동 확인
공지사항 상세 정보 클릭 후 뒤로가기,목록 버튼 클릭시 해당 currentPage로 가도록 코드 수정 추가적으로 공지사항 페이지 검색기능 오류 확인
버튼을 누르면 input태그에 있는 값을 못들고 가는 오류 수정중